### PR TITLE
Build debian packages and push them to packagecloud

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,9 +15,28 @@ jobs:
     steps:
       - checkout
       - run: mkdir -p bin && go build -o bin/statsite-rewrite-sink
+      - store_artifacts:
+          path: bin
       - persist_to_workspace:
           root: .
           paths: bin/*
+  release:
+    docker:
+      - image: circleci/ruby:2.4.2
+    steps:
+      - checkout
+      - run: |
+          gem install fpm --no-ri --no-rdoc --version 1.3.3
+          gem install package_cloud --no-ri --no-rdoc
+      - attach_workspace:
+          at: .
+      - run: |
+          mkdir -p pkg tmp/bin
+          cp bin/* tmp/bin
+          cd pkg && fpm -C ../tmp -t deb -s dir --name statsite-rewrite-sink --version 1.0.0+git~${CIRCLE_SHA1} --prefix /usr/local/ --provides statsite-rewrite-sink --force .
+      - store_artifacts:
+          path: pkg
+      - run: package_cloud push --skip-errors geckoboard/public-geckoboard-tooling/ubuntu/xenial pkg/*.deb
 
 workflows:
   version: 2
@@ -25,3 +44,6 @@ workflows:
     jobs:
       - build
       - test
+      - release:
+          requires:
+            - build


### PR DESCRIPTION
Storing as artifacts so people can download the binaries without
installing our apt repo.